### PR TITLE
Updated the url regex for 'https'.

### DIFF
--- a/QGIS/QGIS.download.recipe
+++ b/QGIS/QGIS.download.recipe
@@ -21,7 +21,7 @@ This probably isn't the best way to do it, but it's simple and works for now.</s
         <key>SEARCH_URL</key>
         <string>https://www.qgis.org/en/site/forusers/download.html</string>
         <key>SEARCH_PATTERN</key>
-        <string>(?P&lt;url&gt;http\://qgis\.org/downloads/macOS/QGIS-%QGIS_MAJOR_VERSION%-(?P&lt;version&gt;[0-9.-]+)\.dmg)</string>
+        <string>(?P&lt;url&gt;https\://qgis\.org/downloads/macOS/QGIS-%QGIS_MAJOR_VERSION%-(?P&lt;version&gt;[0-9.-]+)\.dmg)</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>


### PR DESCRIPTION
Hi. QGIS appears to have gone to https for their downloads. I have corrected this. Thanks.