### PR TITLE
Basic python3 compatibility

### DIFF
--- a/ARCHICAD/ARCHICADUpdatesProcessor.py
+++ b/ARCHICAD/ARCHICADUpdatesProcessor.py
@@ -14,12 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
+
 import json
-import requests
 import subprocess
 import sys
+
+import requests
+
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["ARCHICADUpdatesProcessor"]

--- a/ARCHICAD/ARCHICADUpdatesProcessor.py
+++ b/ARCHICAD/ARCHICADUpdatesProcessor.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import print_function
 import json
 import requests
 import subprocess
@@ -78,8 +80,8 @@ class ARCHICADUpdatesProcessor(Processor):
                 response = subprocess.check_output(curl_cmd)
                 json_data = json.loads(response)
             except subprocess.CalledProcessError as error:
-                print ('return code = ', error.returncode)
-                print ('result = ', error)  
+                print(('return code = ', error.returncode))
+                print(('result = ', error))  
 
         # Parse through the available downloads for versions that match the requested paramters.
         for json_Object in json_data:

--- a/ARCHICAD/ARCHICADUpdatesProcessor.py
+++ b/ARCHICAD/ARCHICADUpdatesProcessor.py
@@ -66,7 +66,7 @@ class ARCHICADUpdatesProcessor(Processor):
             # Grab the available downloads.
             response = requests.get('https://www.graphisoft.com/downloads/db-v3.json')
             json_data = response.json()
-        except Exception:
+        except BaseException:
             # If requests fails (running on macOS 10.12 or older), resort to using curl.
             sys.exc_clear()
 

--- a/ARCHICAD/ARCHICADUpdatesProcessor.py
+++ b/ARCHICAD/ARCHICADUpdatesProcessor.py
@@ -17,17 +17,12 @@
 from __future__ import absolute_import, print_function
 
 import json
-import subprocess
-import sys
 
-import requests
-
-from autopkglib import Processor, ProcessorError
+from autopkglib import Processor, ProcessorError, URLGetter
 
 __all__ = ["ARCHICADUpdatesProcessor"]
 
-class ARCHICADUpdatesProcessor(Processor):
-
+class ARCHICADUpdatesProcessor(URLGetter):
     """This processor finds the URL for the desired version, localization, and type of ARCHICAD.
     """
 
@@ -57,6 +52,7 @@ class ARCHICADUpdatesProcessor(Processor):
     description = __doc__
 
     def main(self):
+        """Main process."""
 
         # Define some variables.
         major_version = self.env.get("major_version")
@@ -64,35 +60,18 @@ class ARCHICADUpdatesProcessor(Processor):
         release_type = self.env.get("release_type")
         available_builds = {}
 
-        try:
-            # Grab the available downloads.
-            response = requests.get('https://www.graphisoft.com/downloads/db-v3.json')
-            json_data = response.json()
-        except Exception:
-            # If requests fails (running on macOS 10.12 or older), resort to using curl.
-            sys.exc_clear()
-
-            # Build the command.
-            curl_cmd = ['/usr/bin/curl', '--silent', '--show-error', '--no-buffer', '--fail',
-                        '--speed-time', '30',
-                        '--location',
-                        '--header', 'Accept: application/json'
-                        '--url', 'https://www.graphisoft.com/downloads/db-v3.json']
-            try:
-                response = subprocess.check_output(curl_cmd)
-                json_data = json.loads(response)
-            except subprocess.CalledProcessError as error:
-                print(('return code = ', error.returncode))
-                print(('result = ', error))  
+        # Grab the available downloads.
+        response = self.download('https://www.graphisoft.com/downloads/db-v3.json')
+        json_data = json.loads(response)
 
         # Parse through the available downloads for versions that match the requested paramters.
-        for json_Object in json_data:
-            if json_Object.get('version') == major_version:
-                if json_Object.get('localization') == localization:
-                    if json_Object.get('type') == release_type:
-                        for details in json_Object['downloadLinks']:
-                            if details.get('platform') == 'mac':
-                                available_builds[json_Object.get('build')] = details['url']
+        for json_object in json_data:
+            if all((json_object.get('version') == major_version,
+                    json_object.get('localization') == localization,
+                    json_object.get('type') == release_type)):
+                for details in json_object['downloadLinks']:
+                    if details.get('platform') == 'mac':
+                        available_builds[json_object.get('build')] = details['url']
 
         # Get the latest version.
         build = sorted(available_builds.keys())[-1]
@@ -107,5 +86,5 @@ class ARCHICADUpdatesProcessor(Processor):
             raise ProcessorError("Unable to find a url based on the parameters provided.")
 
 if __name__ == "__main__":
-    processor = ARCHICADUpdatesProcessor()
-    processor.execute_shell()
+    PROCESSOR = ARCHICADUpdatesProcessor()
+    PROCESSOR.execute_shell()

--- a/ARCHICAD/ARCHICADUpdatesProcessor.py
+++ b/ARCHICAD/ARCHICADUpdatesProcessor.py
@@ -68,7 +68,7 @@ class ARCHICADUpdatesProcessor(Processor):
             # Grab the available downloads.
             response = requests.get('https://www.graphisoft.com/downloads/db-v3.json')
             json_data = response.json()
-        except BaseException:
+        except Exception:
             # If requests fails (running on macOS 10.12 or older), resort to using curl.
             sys.exc_clear()
 

--- a/Maple/MaplePatchProcessor.py
+++ b/Maple/MaplePatchProcessor.py
@@ -25,9 +25,9 @@ import requests  # Use requests if available
 from autopkglib import Processor, ProcessorError
 
 try:
-    from urllib import request as urllib  # For Python 3
+    from urllib.request import urlopen  # For Python 3
 except ImportError:
-    import urllib  # For Python 2
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["MaplePatchProcessor"]
 
@@ -69,7 +69,7 @@ class MaplePatchProcessor(Processor):
                 sys.exc_clear()
 
                 try:
-                    response = urllib.urlopen(url)
+                    response = urlopen(url)
                     return response.read()
                 except BaseException:
                     # If still fails (running on macOS 10.12 or older), resort to using curl

--- a/Maple/MaplePatchProcessor.py
+++ b/Maple/MaplePatchProcessor.py
@@ -71,7 +71,7 @@ class MaplePatchProcessor(Processor):
                 try:
                     response = urlopen(url)
                     return response.read()
-                except BaseException:
+                except Exception:
                     # If still fails (running on macOS 10.12 or older), resort to using curl
                     sys.exc_clear()
 

--- a/Maple/MaplePatchProcessor.py
+++ b/Maple/MaplePatchProcessor.py
@@ -71,7 +71,7 @@ class MaplePatchProcessor(Processor):
                 try:
                     response = urllib.urlopen(url)
                     return response.read()
-                except Exception:
+                except BaseException:
                     # If still fails (running on macOS 10.12 or older), resort to using curl
                     sys.exc_clear()
 

--- a/Maple/MaplePatchProcessor.py
+++ b/Maple/MaplePatchProcessor.py
@@ -14,24 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, print_function
-
-import subprocess
-import sys
 import xml.etree.ElementTree as ET
-
-import requests  # Use requests if available
-
-from autopkglib import Processor, ProcessorError
-
-try:
-    from urllib.request import urlopen  # For Python 3
-except ImportError:
-    from urllib2 import urlopen  # For Python 2
+from autopkglib import Processor, ProcessorError, URLGetter
 
 __all__ = ["MaplePatchProcessor"]
 
-class MaplePatchProcessor(Processor):
+class MaplePatchProcessor(URLGetter):
 
     """This processor finds the URL for the desired Xerox print driver version.
     """
@@ -54,36 +42,6 @@ class MaplePatchProcessor(Processor):
     description = __doc__
 
     def main(self):
-
-        def webContent(url):
-            """A helper function for getting the contents of a web page.
-            Args:
-                url:  The url of the web page.
-            Returns:
-                stdout:  Text content of the web page.
-            """
-            try:
-                response = requests.get(url)
-                return response.content
-            except:
-                sys.exc_clear()
-
-                try:
-                    response = urlopen(url)
-                    return response.read()
-                except Exception:
-                    # If still fails (running on macOS 10.12 or older), resort to using curl
-                    sys.exc_clear()
-
-                    # Build the command.
-                    curl_cmd = '/usr/bin/curl --silent --show-error --no-buffer --fail --speed-time 30 --url "{}"'.format(url)
-                    try:
-                        response = subprocess.check_output(curl_cmd, shell=True)
-                        return response
-                    except subprocess.CalledProcessError as error:
-                        print(('Return code:  {}'.format(error.returncode)))
-                        print(('Result:  {}'.format(error)))
-
 
         # Define variables
         major_version = self.env.get('major_version')
@@ -108,7 +66,7 @@ class MaplePatchProcessor(Processor):
         lookupURL = 'http://update.maplesoft.com/update.php?uuid={uuid}'.format(uuid=uuid)
 
         # Look up the model
-        xml = webContent(lookupURL)
+        xml = self.download(lookupURL)
         # self.output('Results:  \n{}'.format(xml))
 
         if xml:

--- a/Maple/MaplePatchProcessor.py
+++ b/Maple/MaplePatchProcessor.py
@@ -14,17 +14,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import print_function
-import requests # Use requests if available
+from __future__ import absolute_import, print_function
+
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+
+import requests  # Use requests if available
+
+from autopkglib import Processor, ProcessorError
+
 try:
     from urllib import request as urllib  # For Python 3
 except ImportError:
     import urllib  # For Python 2
-import subprocess
-import sys
-import xml.etree.ElementTree as ET
-from autopkglib import Processor, ProcessorError
 
 __all__ = ["MaplePatchProcessor"]
 

--- a/Maple/MaplePatchProcessor.py
+++ b/Maple/MaplePatchProcessor.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import print_function
 import requests # Use requests if available
 try:
     from urllib import request as urllib  # For Python 3
@@ -76,8 +78,8 @@ class MaplePatchProcessor(Processor):
                         response = subprocess.check_output(curl_cmd, shell=True)
                         return response
                     except subprocess.CalledProcessError as error:
-                        print('Return code:  {}'.format(error.returncode))
-                        print('Result:  {}'.format(error))
+                        print(('Return code:  {}'.format(error.returncode)))
+                        print(('Result:  {}'.format(error)))
 
 
         # Define variables

--- a/Shared Processors/ExtractWith7z.py
+++ b/Shared Processors/ExtractWith7z.py
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import shutil
 import subprocess

--- a/Shared Processors/ExtractWith7z.py
+++ b/Shared Processors/ExtractWith7z.py
@@ -17,14 +17,17 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import shutil
 import subprocess
+
+from autopkglib import Processor, ProcessorError
+
 try:
     from shutil import which as find_binary # For Python 3
 except ImportError:
     from distutils.spawn import find_executable as find_binary # For Python 2
-from autopkglib import Processor, ProcessorError
 
 __all__ = ["ExtractWith7z"]
 

--- a/Shared Processors/ExtractWith7z.py
+++ b/Shared Processors/ExtractWith7z.py
@@ -19,7 +19,7 @@
 from __future__ import absolute_import
 
 import os
-import shutil
+from shutil import rmtree
 import subprocess
 
 from autopkglib import Processor, ProcessorError
@@ -89,7 +89,7 @@ class ExtractWith7z(Processor):
                 path = os.path.join(destination_path, entry)
                 try:
                     if os.path.isdir(path) and not os.path.islink(path):
-                        shutil.rmtree(path)
+                        rmtree(path)
                     else:
                         os.unlink(path)
                 except OSError as err:
@@ -118,7 +118,7 @@ class ExtractWith7z(Processor):
                     (_, stderr) = result.communicate()
                 except subprocess.CalledProcessError as error:
                     raise ProcessorError('{binary} execution failed with error code {error_code}:  \n{error}'.format(binary=os.path.basename(cmd[0]), error_code=error.returncode, error=error))
-                
+
                 if result.returncode != 0:
                     raise ProcessorError("Extracting {archive_path} with {binary} failed with:  {error}".format(archive_path=archive_path, binary=os.path.basename(cmd[0]), error=stderr))
 
@@ -126,7 +126,7 @@ class ExtractWith7z(Processor):
 
                 found_binary = '0'
                 break
-            
+
         if found_binary != '0':
             raise ProcessorError("ERROR:  Unable to locate a 7z compatible binary!")
 

--- a/Shared Processors/FileMode.py
+++ b/Shared Processors/FileMode.py
@@ -16,7 +16,9 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
+
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["FileMode"]

--- a/Shared Processors/FileMode.py
+++ b/Shared Processors/FileMode.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 from autopkglib import Processor, ProcessorError
 
@@ -45,7 +46,7 @@ class FileMode(Processor):
             try:
                 os.chmod(self.env['file_path'], int(self.env['file_mode'], 8))
                 self.output("Set permissions on file at %s" % self.env['file_path'])
-            except BaseException, err:
+            except BaseException as err:
                 raise ProcessorError(
                     "Can't set mode of %s to %s: %s"
                     % (self.env['file_path'], self.env['file_mode'], err))

--- a/Shared Processors/FileMode.py
+++ b/Shared Processors/FileMode.py
@@ -48,7 +48,7 @@ class FileMode(Processor):
             try:
                 os.chmod(self.env['file_path'], int(self.env['file_mode'], 8))
                 self.output("Set permissions on file at %s" % self.env['file_path'])
-            except BaseException as err:
+            except Exception as err:
                 raise ProcessorError(
                     "Can't set mode of %s to %s: %s"
                     % (self.env['file_path'], self.env['file_mode'], err))

--- a/Shared Processors/JVMVersioner.py
+++ b/Shared Processors/JVMVersioner.py
@@ -49,7 +49,7 @@ class JVMVersioner(Processor):
 
         try:
             plist_contents = plist_Reader(plist)
-        except Exception:
+        except BaseException:
             raise ProcessorError('Unable to locate the specified plist file.')
 
         # Get the latest version.

--- a/Shared Processors/JVMVersioner.py
+++ b/Shared Processors/JVMVersioner.py
@@ -51,7 +51,7 @@ class JVMVersioner(Processor):
 
         try:
             plist_contents = plist_Reader(plist)
-        except BaseException:
+        except Exception:
             raise ProcessorError('Unable to locate the specified plist file.')
 
         # Get the latest version.

--- a/Shared Processors/JVMVersioner.py
+++ b/Shared Processors/JVMVersioner.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 try:
     from plistlib import load as plist_Reader  # For Python 3
 except ImportError:

--- a/Shared Processors/JVMVersioner.py
+++ b/Shared Processors/JVMVersioner.py
@@ -15,11 +15,13 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
+from autopkglib import Processor, ProcessorError
+
 try:
     from plistlib import load as plist_Reader  # For Python 3
 except ImportError:
     from plistlib import readPlist as plist_Reader  # For Python 2
-from autopkglib import Processor, ProcessorError
 
 __all__ = ["JVMVersioner"]
 

--- a/Shared Processors/TextFileReader.py
+++ b/Shared Processors/TextFileReader.py
@@ -16,10 +16,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import re
+
 import os.path
-from autopkglib.DmgMounter import DmgMounter
+import re
+
 from autopkglib import Processor, ProcessorError
+from autopkglib.DmgMounter import DmgMounter
 
 __all__ = ["TextFileReader"]
 

--- a/Shared Processors/TextFileReader.py
+++ b/Shared Processors/TextFileReader.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import re
 import os.path
 from autopkglib.DmgMounter import DmgMounter

--- a/Shared Processors/TextFileReader.py
+++ b/Shared Processors/TextFileReader.py
@@ -84,13 +84,13 @@ class TextFileReader(DmgMounter):
                     self.env["match"] = match
                     self.output("match: {}".format(self.env["match"]))
 
-            except BaseException as err:
+            except Exception as err:
                 raise ProcessorError("Unable to find a match based on the parameters provided.")
 
             finally:
                 self.unmount(dmg_path)
 
-        except BaseException as err:
+        except Exception as err:
             raise ProcessorError("Unable to find a dmg, error: %s" % err)
 
 if __name__ == "__main__":

--- a/Shared Processors/VersionMajorMinor.py
+++ b/Shared Processors/VersionMajorMinor.py
@@ -19,9 +19,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-from autopkglib import Processor, ProcessorError
+
 import re
 
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["VersionMajorMinor"]
 

--- a/Shared Processors/VersionMajorMinor.py
+++ b/Shared Processors/VersionMajorMinor.py
@@ -18,6 +18,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 import re
 

--- a/Shared Processors/VersionSubstituter.py
+++ b/Shared Processors/VersionSubstituter.py
@@ -18,6 +18,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 
 

--- a/Shared Processors/VersionSubstituter.py
+++ b/Shared Processors/VersionSubstituter.py
@@ -19,8 +19,8 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-from autopkglib import Processor, ProcessorError
 
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["VersionSubstituter"]
 

--- a/Solstice/SolsticeProcessor.py
+++ b/Solstice/SolsticeProcessor.py
@@ -102,7 +102,7 @@ class SolsticeProcessor(Processor):
         # Get the contents of the plist file.
         try:
             plist_contents = plist_Reader(plist)
-        except Exception:
+        except BaseException:
             raise ProcessorError('Unable to locate the specified plist file.')
 
         # Get the version and bundle id

--- a/Solstice/SolsticeProcessor.py
+++ b/Solstice/SolsticeProcessor.py
@@ -104,7 +104,7 @@ class SolsticeProcessor(Processor):
         # Get the contents of the plist file.
         try:
             plist_contents = plist_Reader(plist)
-        except BaseException:
+        except Exception:
             raise ProcessorError('Unable to locate the specified plist file.')
 
         # Get the version and bundle id

--- a/Solstice/SolsticeProcessor.py
+++ b/Solstice/SolsticeProcessor.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 import shutil
 import subprocess
@@ -67,8 +69,8 @@ class SolsticeProcessor(Processor):
             try:
                 process = subprocess.Popen(command)
             except subprocess.CalledProcessError as error:
-                print ('return code = ', error.returncode)
-                print ('result = ', error)  
+                print(('return code = ', error.returncode))
+                print(('result = ', error))  
 
             return process
 

--- a/Solstice/SolsticeProcessor.py
+++ b/Solstice/SolsticeProcessor.py
@@ -14,14 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
+
 import os
 import shutil
 import subprocess
 import time
+
 from autopkglib import Processor, ProcessorError
 from SystemConfiguration import SCDynamicStoreCopyConsoleUser
+
 try:
     from plistlib import load as plist_Reader  # For Python 3
 except ImportError:

--- a/Xerox Print Drivers/XeroxPrintDriverProcessor.py
+++ b/Xerox Print Drivers/XeroxPrintDriverProcessor.py
@@ -86,7 +86,7 @@ class XeroxPrintDriverProcessor(Processor):
                 try:
                     response = urlopen(url)
                     return response.read()
-                except BaseException:
+                except Exception:
                     # If still fails (running on macOS 10.12 or older), resort to using curl
                     sys.exc_clear()
 

--- a/Xerox Print Drivers/XeroxPrintDriverProcessor.py
+++ b/Xerox Print Drivers/XeroxPrintDriverProcessor.py
@@ -86,7 +86,7 @@ class XeroxPrintDriverProcessor(Processor):
                 try:
                     response = urllib.urlopen(url)
                     return response.read()
-                except Exception:
+                except BaseException:
                     # If still fails (running on macOS 10.12 or older), resort to using curl
                     sys.exc_clear()
 

--- a/Xerox Print Drivers/XeroxPrintDriverProcessor.py
+++ b/Xerox Print Drivers/XeroxPrintDriverProcessor.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import print_function
 import re
 import json
 import requests # Use requests if available
@@ -91,8 +93,8 @@ class XeroxPrintDriverProcessor(Processor):
                         response = subprocess.check_output(curl_cmd, shell=True)
                         return response
                     except subprocess.CalledProcessError as error:
-                        print('Return code:  {}'.format(error.returncode))
-                        print('Result:  {}'.format(error))
+                        print(('Return code:  {}'.format(error.returncode)))
+                        print(('Result:  {}'.format(error)))
 
 
         # Define variables

--- a/Xerox Print Drivers/XeroxPrintDriverProcessor.py
+++ b/Xerox Print Drivers/XeroxPrintDriverProcessor.py
@@ -14,18 +14,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import print_function
-import re
+from __future__ import absolute_import, print_function
+
 import json
-import requests # Use requests if available
+import re
+import subprocess
+import sys
+
+import requests  # Use requests if available
+
+from autopkglib import Processor, ProcessorError
+
 try:
     from urllib import request as urllib  # For Python 3
 except ImportError:
     import urllib  # For Python 2
-import subprocess
-import sys
-from autopkglib import Processor, ProcessorError
 
 __all__ = ["XeroxPrintDriverProcessor"]
 

--- a/Xerox Print Drivers/XeroxPrintDriverProcessor.py
+++ b/Xerox Print Drivers/XeroxPrintDriverProcessor.py
@@ -26,9 +26,9 @@ import requests  # Use requests if available
 from autopkglib import Processor, ProcessorError
 
 try:
-    from urllib import request as urllib  # For Python 3
+    from urllib.request import urlopen  # For Python 3
 except ImportError:
-    import urllib  # For Python 2
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["XeroxPrintDriverProcessor"]
 
@@ -84,7 +84,7 @@ class XeroxPrintDriverProcessor(Processor):
                 sys.exc_clear()
 
                 try:
-                    response = urllib.urlopen(url)
+                    response = urlopen(url)
                     return response.read()
                 except BaseException:
                     # If still fails (running on macOS 10.12 or older), resort to using curl


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later (including the use of `sys.exc_clear()`, which I'm not familiar with), but this should catch the low-hanging fruit right now.