### PR TITLE
Remove double dot from identifiers

### DIFF
--- a/Zoom/Zoom-ForIT.jss.recipe
+++ b/Zoom/Zoom-ForIT.jss.recipe
@@ -7,7 +7,7 @@
 
 Configure Zoom for your organization with the CONFIG_PLIST Key.</string>
 	<key>Identifier</key>
-	<string>com.github..mlbz521.jss.ZoomUS-ForIT</string>
+	<string>com.github.mlbz521.jss.ZoomUS-ForIT</string>
 	<key>Input</key>
 	<dict>
 		<key>GROUP_TEMPLATE</key>
@@ -70,7 +70,7 @@ Configure Zoom for your organization with the CONFIG_PLIST Key.</string>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github..mlbz521.pkg.ZoomUS-ForIT</string>
+	<string>com.github.mlbz521.pkg.ZoomUS-ForIT</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Zoom/Zoom-ForIT.pkg.recipe
+++ b/Zoom/Zoom-ForIT.pkg.recipe
@@ -7,7 +7,7 @@
 
 Configure Zoom for your organization with the CONFIG_PLIST Key.</string>
 	<key>Identifier</key>
-	<string>com.github..mlbz521.pkg.ZoomUS-ForIT</string>
+	<string>com.github.mlbz521.pkg.ZoomUS-ForIT</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>


### PR DESCRIPTION
I noticed an extra dot in these identifiers and thought that might not be intentional.

Normally you wouldn't want to change identifiers after recipes have already been published, but it looks like neither of these identifiers are referenced by child recipes in the autopkg org. If you have local overrides, you may need to update them manually.