### PR TITLE
Adjust name of CodeSignatureVerifier argument

### DIFF
--- a/AutoCAD/AutoCAD Patch.download.recipe
+++ b/AutoCAD/AutoCAD Patch.download.recipe
@@ -57,7 +57,7 @@ major_version examples:  2021, 2020, 2019, 2018, etc</string>
 			<dict>
 				<key>input_path</key>
 				<string>%pathname%/*.pkg</string>
-				<key>exepected_authority_names</key>
+				<key>expected_authority_names</key>
 				<array>
 					<string>Developer ID Installer: Autodesk (XXKJ396S2Y)</string>
 					<string>Developer ID Certification Authority</string>

--- a/AutoCAD/AutoCADLegacy.download.recipe
+++ b/AutoCAD/AutoCADLegacy.download.recipe
@@ -77,7 +77,7 @@ Supports the installer format found with AutoCAD 2020 and older.</string>
 			<dict>
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
-				<key>exepected_authority_names</key>
+				<key>expected_authority_names</key>
 				<array>
 					<string>Developer ID Installer: Autodesk (XXKJ396S2Y)</string>
 					<string>Developer ID Certification Authority</string>

--- a/Cisco Jabber/Cisco Jabber.download.recipe
+++ b/Cisco Jabber/Cisco Jabber.download.recipe
@@ -112,7 +112,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/*.pkg</string>
-				<key>exepected_authority_names</key>
+				<key>expected_authority_names</key>
 				<array>
 					<string>Developer ID Installer: Cisco (DE8Y96K9QP)</string>
 					<string>Developer ID Certification Authority</string>

--- a/CrowdStrike Falcon/CrowdStrike Falcon Offline.download.recipe
+++ b/CrowdStrike Falcon/CrowdStrike Falcon Offline.download.recipe
@@ -55,7 +55,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%cached_path%/*.pkg</string>
-				<key>exepected_authority_names</key>
+				<key>expected_authority_names</key>
 				<array>
 					<string>Developer ID Installer: CrowdStrike Inc. (X9E956P446)</string>
 					<string>Developer ID Certification Authority</string>

--- a/CrowdStrike Falcon/CrowdStrike Falcon.download.recipe
+++ b/CrowdStrike Falcon/CrowdStrike Falcon.download.recipe
@@ -60,7 +60,7 @@ You must provide a Client ID and Secret along with the Policy ID to determine wh
 			<dict>
 				<key>input_path</key>
 				<string>%pathname%</string>
-				<key>exepected_authority_names</key>
+				<key>expected_authority_names</key>
 				<array>
 					<string>Developer ID Installer: CrowdStrike Inc. (X9E956P446)</string>
 					<string>Developer ID Certification Authority</string>

--- a/JMP/JMP.download.recipe
+++ b/JMP/JMP.download.recipe
@@ -97,7 +97,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
-				<key>exepected_authority_names</key>
+				<key>expected_authority_names</key>
 				<array>
 					<string>Developer ID Installer: SAS Institute Inc. (E828H4LX4D)</string>
 					<string>Developer ID Certification Authority</string>

--- a/Mathematica/Mathematica.download.recipe
+++ b/Mathematica/Mathematica.download.recipe
@@ -157,7 +157,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/scripts/*.pkg</string>
-				<key>exepected_authority_names</key>
+				<key>expected_authority_names</key>
 				<array>
 					<string>Developer ID Installer: Wolfram Research, Inc (D2Y8ST33G6)</string>
 					<string>Developer ID Certification Authority</string>

--- a/SPSS Statistics/SPSSStatistics.download.recipe
+++ b/SPSS Statistics/SPSSStatistics.download.recipe
@@ -114,7 +114,7 @@ Supports the new format found with SPSS v27.</string>
 			<dict>
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%filename%</string>
-				<key>exepected_authority_names</key>
+				<key>expected_authority_names</key>
 				<array>
 					<string>Developer ID Installer: International  Business Machines Corp (PETKK2G752)</string>
 					<string>Developer ID Certification Authority</string>

--- a/Zoom/Zoom-ForIT.download.recipe
+++ b/Zoom/Zoom-ForIT.download.recipe
@@ -39,7 +39,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%pathname%</string>
-				<key>exepected_authority_names</key>
+				<key>expected_authority_names</key>
 					<array>
 						<string>Developer ID Installer: Zoom Video Communications, Inc.</string>
 						<string>Developer ID Certification Authority</string>

--- a/Zoom/Zoom-OutlookPlugin.download.recipe
+++ b/Zoom/Zoom-OutlookPlugin.download.recipe
@@ -39,7 +39,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%pathname%</string>
-				<key>exepected_authority_names</key>
+				<key>expected_authority_names</key>
 					<array>
 						<string>Developer ID Installer: Zoom Video Communications, Inc.</string>
 						<string>Developer ID Certification Authority</string>

--- a/iManage Work/iManageWork.download.recipe
+++ b/iManage Work/iManageWork.download.recipe
@@ -75,7 +75,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/iManage Work.pkg</string>
-				<key>exepected_authority_names</key>
+				<key>expected_authority_names</key>
 				<array>
 					<string>Developer ID Installer: iManage LLC (HGLC38RWEJ)</string>
 					<string>Developer ID Certification Authority</string>


### PR DESCRIPTION
Correct argument name is `expected_authority_names`. (https://github.com/autopkg/autopkg/wiki/Processor-CodeSignatureVerifier)