### PR TITLE
Changed package and app names to "Google Drive"

### DIFF
--- a/Google Drive FileStream/GoogleDriveFileStream.pkg.recipe
+++ b/Google Drive FileStream/GoogleDriveFileStream.pkg.recipe
@@ -23,7 +23,7 @@
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/expanded</string>
 				<key>flat_pkg_path</key>
-				<string>%pathname%/GoogleDriveFileStream.pkg</string>
+				<string>%pathname%/GoogleDrive.pkg</string>
 			</dict>
 		</dict>
 		<dict>
@@ -34,7 +34,7 @@
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack</string>
 				<key>pkg_payload_path</key>
-				<string>%RECIPE_CACHE_DIR%/expanded/GoogleDriveFileStream.pkg/Payload</string>
+				<string>%RECIPE_CACHE_DIR%/expanded/GoogleDrive.pkg/Payload</string>
 				<key>purge_destination</key>
 				<string>true</string>
 			</dict>
@@ -45,7 +45,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack/Google Drive File Stream.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/unpack/Google Drive.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>
@@ -56,7 +56,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_pkg</key>
-				<string>%pathname%/GoogleDriveFileStream.pkg</string>
+				<string>%pathname%/GoogleDrive.pkg</string>
 				<key>pkg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
 			</dict>


### PR DESCRIPTION
Referenced in Issue #29, changed names in the pkg recipe to "GoogleDrive.pkg" and "Google Drive.app" to reflect Google's name changes for the app. 