### PR TITLE
Expected authority name changed to include team identifier

### DIFF
--- a/Zoom/Zoom-ForIT.download.recipe
+++ b/Zoom/Zoom-ForIT.download.recipe
@@ -41,7 +41,7 @@
 				<string>%pathname%</string>
 				<key>expected_authority_names</key>
 					<array>
-						<string>Developer ID Installer: Zoom Video Communications, Inc.</string>
+						<string>Developer ID Installer: Zoom Video Communications, Inc. (BJ4HAAB9B3)</string>
 						<string>Developer ID Certification Authority</string>
 						<string>Apple Root CA</string>
 					</array>


### PR DESCRIPTION
Expected authority name changed to include team identifier:

Authority=Developer ID Application: Zoom Video Communications, Inc. (BJ4HAAB9B3)
Authority=Developer ID Certification Authority
Authority=Apple Root CA