### PR TITLE
Google Drive FS pkg_payload_path

### DIFF
--- a/Google Drive FileStream/GoogleDriveFileStream.pkg.recipe
+++ b/Google Drive FileStream/GoogleDriveFileStream.pkg.recipe
@@ -34,7 +34,7 @@
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack</string>
 				<key>pkg_payload_path</key>
-				<string>%RECIPE_CACHE_DIR%/expanded/GoogleDrive.pkg/Payload</string>
+				<string>%RECIPE_CACHE_DIR%/expanded/GoogleDrive_x86_64.pkg/Payload</string>
 				<key>purge_destination</key>
 				<string>true</string>
 			</dict>


### PR DESCRIPTION
Google Drive made their installer Universal and now the payload contains both **GoogleDrive_arm64.pkg** and **GoogleDrive_x86_64.pkg** instead of a single GoogleDrive.pkg. 

The good news is that this only breaks the PkgPayloadUnpacker processor which is only used to pull the version info, so it shouldn't matter which pkg it points to. Updated to point to the x86_64 version and all is working. 

Let me know if you have any feedback, thanks for all your work.