### PR TITLE
GRAPHISOFT made a small change to all download URLs

### DIFF
--- a/ARCHICAD/ARCHICADUpdatesProcessor.py
+++ b/ARCHICAD/ARCHICADUpdatesProcessor.py
@@ -78,6 +78,7 @@ class ARCHICADUpdatesProcessor(URLGetter):
             ):
                 mac_link = json_object.get("downloadLinks", dict()).get("mac", dict()).get("url")
                 if mac_link:
+                    mac_link = 'https://dl.graphisoft.com' + mac_link[3:]
                     available_builds[json_object.get("build")] = mac_link
 
         # Get the latest version.


### PR DESCRIPTION
...by ommiting the server. This update removes what seems to be the placeholder part of the URL and adds a valid server.