### PR TITLE
Solve for #44 - pkg_path not exported

### DIFF
--- a/Zoom/Zoom-OutlookPlugin.jss.recipe
+++ b/Zoom/Zoom-OutlookPlugin.jss.recipe
@@ -45,8 +45,6 @@
 			<string>JSSImporter</string>
 			<key>Arguments</key>
 			<dict>
-				<key>pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
 				<key>prod_name</key>
 				<string>%NAME%</string>
 				<key>category</key>

--- a/Zoom/Zoom-OutlookPlugin.pkg.recipe
+++ b/Zoom/Zoom-OutlookPlugin.pkg.recipe
@@ -54,14 +54,12 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
-			<string>Copier</string>
+			<string>PkgCopier</string>
 			<key>Arguments</key>
 			<dict>
-				<key>destination_path</key>
+				<key>pkg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
-				<key>overwrite</key>
-				<true/>
-				<key>source_path</key>
+				<key>source_pkg</key>
 				<string>%pathname%</string>
 			</dict>
 		</dict>


### PR DESCRIPTION
Changed Copier processor in Zoom-OutlookPlugin.jss.recipe to use PkgCopier, which exports the pkg_path variable, so it doesn't need to be explicitly defined in child recipes