### PR TITLE
Update Python path to reflect changes in macOS 12.3+

### DIFF
--- a/Set.A.Light 3D - Elixxier/SetALightProcessor.py
+++ b/Set.A.Light 3D - Elixxier/SetALightProcessor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2021 Zack Thompson (MLBZ521)
 #
@@ -34,14 +34,9 @@ class SetALightProcessor(URLDownloader):
             "required": True,
         }
     }
-    output_variables = {
-        "url": {
-            "description": ("URL to download.")
-        }
-    }
+    output_variables = {"url": {"description": ("URL to download.")}}
 
     description = __doc__
-
 
     def main(self):
 
@@ -52,18 +47,21 @@ class SetALightProcessor(URLDownloader):
             # Initialize the curl_cmd with the required curl switches
             curl_opts = [
                 self.curl_binary(),
-                "--url", "{}".format(search_url),
-                "--request", "GET",
+                "--url",
+                "{}".format(search_url),
+                "--request",
+                "GET",
                 "--silent",
                 "--show-error",
                 "--no-buffer",
-                "--dump-header", "-",
-                "--fail"
+                "--dump-header",
+                "-",
+                "--fail",
             ]
 
             # Execute curl
             stdout, stderr, returncode = self.execute_curl(curl_opts)
-            parse_results = stdout.split('\n')
+            parse_results = stdout.split("\n")
 
             for item in parse_results:
                 if re.search("location: ", item):

--- a/Shared Processors/ExtractWith7z.py
+++ b/Shared Processors/ExtractWith7z.py
@@ -1,8 +1,8 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2019 Zack T (mlbz521)
 #
-# Inspired by 
+# Inspired by
 #   * Per Olofsson's "Unarchiver.py"
 #   * Matt Hansen's "WinInstallerExtractor.py"
 #   * Yoann Gini's "Zoom7zUnarchiver.py"
@@ -30,6 +30,7 @@ from autopkglib import Processor, ProcessorError
 
 __all__ = ["ExtractWith7z"]
 
+
 class ExtractWith7z(Processor):
 
     """This processor extracts files with a specified 7zip binary."""
@@ -38,30 +39,29 @@ class ExtractWith7z(Processor):
         "archive_path": {
             "required": False,
             "description": "Path to an archive. Defaults to contents of the 'pathname'"
-                            "variable, for example as is set by URLDownloader."
+            "variable, for example as is set by URLDownloader.",
         },
         "destination_path": {
             "required": False,
             "description": "Directory where archive will be unpacked, created "
-                            "if necessary. Defaults to RECIPE_CACHE_DIR/NAME."
+            "if necessary. Defaults to RECIPE_CACHE_DIR/NAME.",
         },
         "purge_destination": {
             "required": False,
             "description": "Whether the contents of the destination directory "
-                           "will be removed before unpacking."
+            "will be removed before unpacking.",
         },
         "7z_path": {
             "required": False,
             "description": "Path to a 7z-compatible binary.  This does not ship"
-                            "with macOS, it will need to be installed manually."
-                            "The processor will prioritize a provided binary, but"
-                            "if it cannot locate it, it'll continue trying to find"
-                            "a 7z-compatible binary in common locations, including"
-                            "the system PATH."
-        }
+            "with macOS, it will need to be installed manually."
+            "The processor will prioritize a provided binary, but"
+            "if it cannot locate it, it'll continue trying to find"
+            "a 7z-compatible binary in common locations, including"
+            "the system PATH.",
+        },
     }
-    output_variables = {
-    }
+    output_variables = {}
 
     description = __doc__
 
@@ -71,12 +71,13 @@ class ExtractWith7z(Processor):
         archive_path = self.env.get("archive_path", self.env.get("pathname"))
 
         if not archive_path:
-            raise ProcessorError(
-                "Path to an archive was not provided!")
+            raise ProcessorError("Path to an archive was not provided!")
 
         custom_path = self.env.get("7z_path", "")
-        destination_path = self.env.get("destination_path", os.path.join(
-            self.env["RECIPE_CACHE_DIR"], self.env["NAME"]))
+        destination_path = self.env.get(
+            "destination_path",
+            os.path.join(self.env["RECIPE_CACHE_DIR"], self.env["NAME"]),
+        )
 
         # Create the directory if needed
         if not os.path.exists(destination_path):
@@ -84,8 +85,9 @@ class ExtractWith7z(Processor):
             try:
                 os.makedirs(destination_path)
             except OSError as err:
-                raise ProcessorError("Failed to create {}:  {}".format(
-                    destination_path, err.strerror))
+                raise ProcessorError(
+                    "Failed to create {}:  {}".format(destination_path, err.strerror)
+                )
 
         elif self.env.get("purge_destination"):
 
@@ -101,8 +103,9 @@ class ExtractWith7z(Processor):
                         os.unlink(path)
 
                 except OSError as err:
-                    raise ProcessorError("Failed to remove {}:  {}".format(
-                        path, err.strerror))
+                    raise ProcessorError(
+                        "Failed to remove {}:  {}".format(path, err.strerror)
+                    )
 
         # Check if a custom binary path was provided
         if custom_path and custom_path != "/path/to/7z":
@@ -111,16 +114,30 @@ class ExtractWith7z(Processor):
             if not os.path.exists(custom_path):
                 raise ProcessorError(
                     "Provided {} binary does not exist at the following path:  {}".format(
-                        os.path.basename(custom_path), os.path.dirname(custom_path)))
+                        os.path.basename(custom_path), os.path.dirname(custom_path)
+                    )
+                )
 
-            self.output("Provided {} binary at the following path:  {}".format(
-                os.path.basename(custom_path), os.path.dirname(custom_path)), verbose_level=2)
-            binary_7z = [ custom_path ]
+            self.output(
+                "Provided {} binary at the following path:  {}".format(
+                    os.path.basename(custom_path), os.path.dirname(custom_path)
+                ),
+                verbose_level=2,
+            )
+            binary_7z = [custom_path]
 
         else:
             # Set the binaries we're going to look for
-            binary_7z = [ "7zz", "/usr/local/7zz/7zz", "7z", "7za", "7zr", "p7zip", "/usr/local/bin/7z", 
-                "/Applications/Keka.app/Contents/MacOS/Keka" ]
+            binary_7z = [
+                "7zz",
+                "/usr/local/7zz/7zz",
+                "7z",
+                "7za",
+                "7zr",
+                "p7zip",
+                "/usr/local/bin/7z",
+                "/Applications/Keka.app/Contents/MacOS/Keka",
+            ]
 
         # Success/Fail Flag
         found_binary = False
@@ -136,36 +153,45 @@ class ExtractWith7z(Processor):
 
                 if re.search("keka", path, re.IGNORECASE):
                     cmd = [
-                        "{}".format(path), 
+                        "{}".format(path),
                         "--client",
                         "7z",
-                        "x", 
-                        "{}".format(archive_path), 
-                        "-o{}".format(destination_path)
+                        "x",
+                        "{}".format(archive_path),
+                        "-o{}".format(destination_path),
                     ]
                 else:
                     cmd = [
-                        "{}".format(path), 
-                        "x", 
-                        "{}".format(archive_path), 
-                        "-o{}".format(destination_path)
+                        "{}".format(path),
+                        "x",
+                        "{}".format(archive_path),
+                        "-o{}".format(destination_path),
                     ]
 
                 try:
-                    result = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                    result = subprocess.Popen(
+                        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                    )
                     (_, stderr) = result.communicate()
                 except subprocess.CalledProcessError as error:
                     raise ProcessorError(
                         "{} execution failed with error code {}:  \n{}".format(
-                            os.path.basename(cmd[0]), error.returncode, error))
+                            os.path.basename(cmd[0]), error.returncode, error
+                        )
+                    )
 
                 if result.returncode != 0:
                     raise ProcessorError(
                         "Extracting {} with {} failed with:  {}".format(
-                            archive_path, os.path.basename(cmd[0]), stderr))
+                            archive_path, os.path.basename(cmd[0]), stderr
+                        )
+                    )
 
-                self.output("Extracted {} to {}".format(
-                    os.path.basename(archive_path), destination_path))
+                self.output(
+                    "Extracted {} to {}".format(
+                        os.path.basename(archive_path), destination_path
+                    )
+                )
 
                 break
 

--- a/Shared Processors/FileMode.py
+++ b/Shared Processors/FileMode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2011 Per Olofsson
 # Modified 2018 by Zack Thompson
@@ -23,6 +23,7 @@ from autopkglib import Processor, ProcessorError
 
 __all__ = ["FileMode"]
 
+
 class FileMode(Processor):
 
     """This processor essentinally runs `chmod` on a file.
@@ -37,22 +38,23 @@ class FileMode(Processor):
         },
         "file_mode": {
             "required": True,
-            "description": "String. Numeric mode for file in octal format."
-        }
+            "description": "String. Numeric mode for file in octal format.",
+        },
     }
-    output_variables = {
-    }
+    output_variables = {}
 
     def main(self):
-        if 'file_mode' in self.env:
+        if "file_mode" in self.env:
             try:
-                os.chmod(self.env['file_path'], int(self.env['file_mode'], 8))
-                self.output("Set permissions on file at %s" % self.env['file_path'])
+                os.chmod(self.env["file_path"], int(self.env["file_mode"], 8))
+                self.output("Set permissions on file at %s" % self.env["file_path"])
             except Exception as err:
                 raise ProcessorError(
                     "Can't set mode of %s to %s: %s"
-                    % (self.env['file_path'], self.env['file_mode'], err))
+                    % (self.env["file_path"], self.env["file_mode"], err)
+                )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     PROCESSOR = FileMode()
     PROCESSOR.execute_shell()


### PR DESCRIPTION
As of macOS Monterey 12.3, the version of Python 2 that shipped with macOS located at `/usr/bin/python` [has been removed](https://developer.apple.com/documentation/macos-release-notes/macos-12_3-release-notes). More context can be found in some posts from Mac admins at the beginning of 2022, aggregated [here](https://scriptingosx.com/2022/03/macos-monterey-12-3-removes-python-2-link-collection/).

Since [version 2.0.2](https://github.com/autopkg/autopkg/releases/tag/v2.0.2), AutoPkg's installer has included its own Python 3 framework, symlinked from `/usr/local/autopkg/python`. Similarly, Munki ships with its own Python 3 framework, symlinked from `/usr/local/munki/munki-python`. This pull request adjusts the shebang and interpreter paths of processors, pre/post install scripts, and other files to replace `/usr/bin/python` with the AutoPkg or Munki Python 3 symlinks as appropriate.

NOTE: Because AutoPkg processors are imported as modules by AutoPkg and not executed directly, processors' shebang has no effect in normal usage. However: (a) some people execute processors directly during testing, and these tests won't work unless the shebang points to a valid Python 3, and (b) having instances of `/usr/bin/python` in the codebase could lead to confusion for people not deeply familiar with processor behavior.