### PR TITLE
Update versioning

### DIFF
--- a/Zoom/Zoom-ForIT.pkg.recipe
+++ b/Zoom/Zoom-ForIT.pkg.recipe
@@ -81,21 +81,22 @@ https://support.zoom.us/hc/en-us/articles/115001799006-Mass-Deployment-with-Prec
 			</dict>
 		</dict>            
 		<dict>
-			<key>Processor</key>
-			<string>Versioner</string>
 			<key>Arguments</key>
 			<dict>
-				<key>input_plist_path</key>
+				<key>info_path</key>
 				<string>%RECIPE_CACHE_DIR%/payload/zoom.us.app/Contents/Info.plist</string>
-				<key>plist_version_key</key>
-				<string>CFBundleShortVersionString</string>
+				<key>plist_keys</key>
+				<dict>
+					<key>CFBundleVersion</key>
+					<string>version</string>
+					<key>CFBundleShortVersionString</key>
+					<string>jamfversion</string>
+					<key>LSMinimumSystemVersion</key>
+					<string>min_os_version</string>
+				</dict>
 			</dict>
-		</dict>
-		<dict>
-			<key>Comment</key>
-			<string>The version used by Zoom is in the format "4.5.0 (3261.0825)" which isn't accepted by pkgbuild when building the package. This processor splits the version to just the "4.5.0" part.</string>
 			<key>Processor</key>
-			<string>com.github.homebysix.VersionSplitter/VersionSplitter</string>
+			<string>PlistReader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>


### PR DESCRIPTION
This change will provide the full version string for Zoom instead of the truncated version. Example: 5.12.2.11434 instead of 5.12.2

Additionally it provides a "jamfversion" that can be used with new JamfUploader (.jamf) policies. This is useful for updating the Zoom jamf patch policies with versions formatted like: 5.12.2 (11434)

Changes copied from: [https://github.com/autopkg/homebysix-recipes/blob/master/Zoom/Zoom.pkg.recipe](https://github.com/autopkg/homebysix-recipes/blob/master/Zoom/Zoom.pkg.recipe)