### PR TITLE
Quote hyphen in yaml

### DIFF
--- a/Jamf Pro Tools/Composer.download.recipe.yaml
+++ b/Jamf Pro Tools/Composer.download.recipe.yaml
@@ -8,7 +8,7 @@ Input:
   NAME_LIMITATION: null
   NAME_EXCEPTION: testing
   FILE_SHARE: /path/to/offline/repository
-  VERSION_STRING_SEPARATOR: -
+  VERSION_STRING_SEPARATOR: "-"
   MAX_FOLDER_DEPTH: 1
 Process:
   - Processor: com.github.mlbz521.SharedProcessors/OfflineApps


### PR DESCRIPTION
This is preventing parsing the yaml in Python.