### PR TITLE
Update Composer.pkg.recipe.yaml

### DIFF
--- a/Jamf Pro Tools/Composer.pkg.recipe.yaml
+++ b/Jamf Pro Tools/Composer.pkg.recipe.yaml
@@ -10,7 +10,7 @@ Input:
   NAME_LIMITATION: null
   NAME_EXCEPTION: testing
   FILE_SHARE: /path/to/offline/repository
-  VERSION_STRING_SEPARATOR: -
+  VERSION_STRING_SEPARATOR: "-"
   MAX_FOLDER_DEPTH: 1
 Process:
   - Processor: AppPkgCreator


### PR DESCRIPTION
Put dash character for VERSION_STRING_SEPARATOR in quotes. This should get it to be interpreted as a literal character instead of the start of a list.

Without quotes AutoPkg was throwing a "sequence entries are not allowed here" error:
```
WARNING: yaml error for /Users/autopkg/Library/AutoPkg/RecipeRepos/com.github.autopkg.MLBZ521-recipes/Jamf Pro Tools/Composer.pkg.recipe.yaml: sequence entries are not allowed here
  in "/Users/autopkg/Library/AutoPkg/RecipeRepos/com.github.autopkg.MLBZ521-recipes/Jamf Pro Tools/Composer.pkg.recipe.yaml", line 13, column 29
```