### PR TITLE
if file not dmg allow continuing through the processor

### DIFF
--- a/Shared Processors/XarExtractSingleFile.py
+++ b/Shared Processors/XarExtractSingleFile.py
@@ -139,6 +139,8 @@ class XarExtractSingleFile(DmgMounter):
 
             except Exception as error:
                 raise ProcessorError("Failed matching path with glob.") from error
+        else:
+            matched_archive_path = archive_path
 
         # Wrap in a try/finally so if a dmg is mounted, it will always be unmounted
         try:


### PR DESCRIPTION
The fixes made to add glob support for dmg's broke the flow if it was a pkg. This fix will allow a pkg input to pass through as before. 
error before fix: 
```
Traceback (most recent call last):
  File "/Library/AutoPkg/autopkglib/__init__.py", line 840, in process
    self.env = processor.process()
  File "/Library/AutoPkg/autopkglib/__init__.py", line 626, in process
    self.main()
  File "XarExtractSingleFile.py", line 147, in main
    cmd_list_files = f"/usr/bin/xar -tf '{matched_archive_path}'"
UnboundLocalError: local variable 'matched_archive_path' referenced before assignment
  File "/Library/AutoPkg/autopkglib/__init__.py", line 840, in process
    self.env = processor.process()
```