### PR TITLE
Add code signature verification for QGIS

### DIFF
--- a/QGIS/QGIS.download.recipe
+++ b/QGIS/QGIS.download.recipe
@@ -32,15 +32,6 @@ Long Term (support) Release = "ltr"</string>
                 <string>%URL%</string>
             </dict>
         </dict>
-		<dict>
-			<key>Processor</key>
-			<string>AppDmgVersioner</string>
-			<key>Arguments</key>
-			<dict>
-				<key>dmg_path</key>
-				<string>%pathname%</string>
-			</dict>
-		</dict>
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>

--- a/QGIS/QGIS.download.recipe
+++ b/QGIS/QGIS.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of QGIS.  Requires python.org Python 3.6 to be pre-installed - other distributions are not supported.
+    <string>Downloads the latest version of QGIS.  Requires python.org Python 3 to be pre-installed - other distributions are not supported.
 
 Supports either the latest release or Long Term (support) Release.  Override the key "RELEASE_TYPE" to specify which you need:
 Latest Release = "pr"
@@ -35,6 +35,17 @@ Long Term (support) Release = "ltr"</string>
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/QGIS.app</string>
+                <key>requirement</key>
+                <string>identifier "org.qgis.qgis3" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4F7N4UDA22"</string>
+            </dict>
         </dict>
     </array>
 </dict>

--- a/QGIS/QGIS.pkg.recipe
+++ b/QGIS/QGIS.pkg.recipe
@@ -29,6 +29,15 @@ Notes:
 	<array>
 		<dict>
 			<key>Processor</key>
+			<string>AppDmgVersioner</string>
+			<key>Arguments</key>
+			<dict>
+				<key>dmg_path</key>
+				<string>%pathname%</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>PkgRootCreator</string>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
This PR adds code signature verification to the QGIS recipes. It also moves AppDmgVersioner to the pkg recipe in order to prevent redundancy with downstream recipes (specifically the QGIS.munki recipe in the robperc-recipes repo, which may be using your download recipe as a parent shortly).

With this change, I'm setting you up to be "one true" QGIS download recipe in the AutoPkg org. We're all counting on you. ;-)