### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/AmazonCorretto/AmazonCorretto-Universal.pkg.recipe.yaml
+++ b/AmazonCorretto/AmazonCorretto-Universal.pkg.recipe.yaml
@@ -148,7 +148,6 @@ Process:
     Arguments:
       pkg_request:
         id: 'com.amazon.corretto.%JDK_MAJOR_VERSION%'
-        options: purge_ds_store
         pkgname: '%NAME%-%version%'
         pkgroot: '%RECIPE_CACHE_DIR%/pkgroot'
         pkgtype: flat

--- a/Anaconda/Anaconda-Universal.pkg.recipe.yaml
+++ b/Anaconda/Anaconda-Universal.pkg.recipe.yaml
@@ -126,7 +126,6 @@ Process:
     Arguments:
       pkg_request:
         id: "%PKG_ID_PREFIX%.%version%.pkg"
-        options: purge_ds_store
         pkgname: "%NAME%-%version%"
         pkgroot: "%RECIPE_CACHE_DIR%/pkgroot"
         pkgtype: flat

--- a/Android Studio/Android Studio.pkg.recipe.yaml
+++ b/Android Studio/Android Studio.pkg.recipe.yaml
@@ -155,7 +155,6 @@ Process:
   Arguments:
     pkg_request:
       id: '%bundleid%'
-      options: purge_ds_store
       pkgname: '%NAME%-%version%'
       pkgroot: '%RECIPE_CACHE_DIR%/pkgroot'
       pkgtype: flat

--- a/Arduino/Arduino.pkg.recipe.yaml
+++ b/Arduino/Arduino.pkg.recipe.yaml
@@ -162,7 +162,6 @@ Process:
   Arguments:
     pkg_request:
       id: cc.arduino.Arduino.pkg
-      options: purge_ds_store
       pkgname: '%NAME%-%version%'
       pkgroot: '%RECIPE_CACHE_DIR%/pkgroot'
       pkgtype: flat

--- a/BeyondTrust_Bomgar/BeyondTrustRemoteSupportJumpClient.pkg.recipe.yaml
+++ b/BeyondTrust_Bomgar/BeyondTrustRemoteSupportJumpClient.pkg.recipe.yaml
@@ -66,7 +66,6 @@ Process:
     Arguments:
       pkg_request:
         id: '%bundleid%'
-        options: purge_ds_store
         pkgname: '%NAME%-%version%'
         pkgroot: '%RECIPE_CACHE_DIR%/pkgroot'
         pkgtype: flat

--- a/BeyondTrust_Bomgar/Bomgar Jump Client.pkg.recipe
+++ b/BeyondTrust_Bomgar/Bomgar Jump Client.pkg.recipe
@@ -90,8 +90,6 @@ The name of the bundled application and the package will be named based on the N
 					<string>%version%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/BeyondTrust_Bomgar/Bomgar Rep Console.pkg.recipe
+++ b/BeyondTrust_Bomgar/Bomgar Rep Console.pkg.recipe
@@ -58,8 +58,6 @@ The name of the bundled application and the package will be named based on the N
 					<string>%version%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/CoreShell Helper/CoreShell Helper.pkg.recipe
+++ b/CoreShell Helper/CoreShell Helper.pkg.recipe
@@ -319,8 +319,6 @@ exit 0</string>
                     <string>flat</string>
                     <key>version</key>
                     <string>%version%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>scripts</key>
                     <string>Scripts</string>
                     <key>chown</key>

--- a/Cytoscape/Cytoscape.pkg.recipe.yaml
+++ b/Cytoscape/Cytoscape.pkg.recipe.yaml
@@ -175,7 +175,6 @@ Process:
   Arguments:
     pkg_request:
       id: org.cytoscape.installer
-      options: purge_ds_store
       pkgname: '%NAME%-%version%'
       pkgroot: '%RECIPE_CACHE_DIR%/pkgroot'
       pkgtype: flat

--- a/Dropbox/Dropbox-Universal.pkg.recipe.yaml
+++ b/Dropbox/Dropbox-Universal.pkg.recipe.yaml
@@ -143,7 +143,6 @@ Process:
     Arguments:
       pkg_request:
         id: '%bundleid%'
-        options: purge_ds_store
         pkgname: '%NAME%-%version%'
         pkgroot: '%RECIPE_CACHE_DIR%/pkgroot'
         pkgtype: flat

--- a/GIMP/GIMP-Universal.pkg.recipe.yaml
+++ b/GIMP/GIMP-Universal.pkg.recipe.yaml
@@ -157,7 +157,6 @@ Process:
   Arguments:
     pkg_request:
       id: org.gimp.gimp
-      options: purge_ds_store
       pkgname: '%NAME%-%version%'
       pkgroot: '%RECIPE_CACHE_DIR%/pkgroot'
       pkgtype: flat

--- a/Jamf Pro Tools/Composer.pkg.recipe.yaml
+++ b/Jamf Pro Tools/Composer.pkg.recipe.yaml
@@ -88,7 +88,6 @@ Process:
     Arguments:
       pkg_request:
         id: "com.jamfsoftware.composer"
-        options: purge_ds_store
         pkgname: "%NAME%-%version%"
         pkgroot: "%RECIPE_CACHE_DIR%/pkgroot"
         pkgtype: flat

--- a/Jamf Pro Tools/JamfAdmin.pkg.recipe.yaml
+++ b/Jamf Pro Tools/JamfAdmin.pkg.recipe.yaml
@@ -91,7 +91,6 @@ Process:
     Arguments:
       pkg_request:
         id: "com.jamfsoftware.JamfAdmin"
-        options: purge_ds_store
         pkgname: "%NAME%-%version%"
         pkgroot: "%RECIPE_CACHE_DIR%/pkgroot"
         pkgtype: flat

--- a/Keybase/Keybase-Universal.pkg.recipe.yaml
+++ b/Keybase/Keybase-Universal.pkg.recipe.yaml
@@ -143,7 +143,6 @@ Process:
     Arguments:
       pkg_request:
         id: '%bundleid%'
-        options: purge_ds_store
         pkgname: '%NAME%-%version%'
         pkgroot: '%RECIPE_CACHE_DIR%/pkgroot'
         pkgtype: flat

--- a/Maple/Maple.offline.pkg.recipe
+++ b/Maple/Maple.offline.pkg.recipe
@@ -125,8 +125,6 @@ exit 0</string>
 					<string>%version%</string>
 					<key>id</key>
 					<string>com.bitrock.appinstaller</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>scripts</key>
 					<string>Scripts</string>
 				</dict>

--- a/Maple/Maple.pkg.recipe.yaml
+++ b/Maple/Maple.pkg.recipe.yaml
@@ -84,7 +84,6 @@ Process:
     Arguments:
       pkg_request:
         id: '%BUNDLE_ID%'
-        options: purge_ds_store
         pkgname: '%NAME%-%installed_version%'
         pkgroot: '%RECIPE_CACHE_DIR%/pkgroot'
         pkgtype: flat

--- a/Mathematica/Mathematica.pkg.recipe
+++ b/Mathematica/Mathematica.pkg.recipe
@@ -121,8 +121,6 @@ exit 0</string>
 					<string>%version%</string>
 					<key>id</key>
 					<string>com.wolfram.Mathematica</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>scripts</key>
 					<string>Scripts</string>
 				</dict>

--- a/Matlab/Matlab Update.pkg.recipe
+++ b/Matlab/Matlab Update.pkg.recipe
@@ -145,8 +145,6 @@ exit 0</string>
 					<string>%version%</string>
 					<key>id</key>
 					<string>com.mathworks.updater</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>scripts</key>
 					<string>Scripts</string>
 				</dict>

--- a/Matlab/Matlab-ISO.pkg.recipe.yaml
+++ b/Matlab/Matlab-ISO.pkg.recipe.yaml
@@ -121,7 +121,6 @@ Process:
 - Arguments:
     pkg_request:
       id: com.mathworks.installer
-      options: purge_ds_store
       pkgname: "%NAME%-%version%"
       pkgroot: "%RECIPE_CACHE_DIR%/pkgroot"
       scripts: Scripts

--- a/Matlab/Matlab-Universal.pkg.recipe.yaml
+++ b/Matlab/Matlab-Universal.pkg.recipe.yaml
@@ -114,7 +114,6 @@ Process:
 - Arguments:
     pkg_request:
       id: com.mathworks.installer
-      options: purge_ds_store
       pkgname: "%NAME%-%version%"
       pkgroot: "%RECIPE_CACHE_DIR%/pkgroot"
       scripts: Scripts

--- a/Matlab/Matlab.pkg.recipe.yaml
+++ b/Matlab/Matlab.pkg.recipe.yaml
@@ -116,7 +116,6 @@ Process:
 - Arguments:
     pkg_request:
       id: com.mathworks.installer
-      options: purge_ds_store
       pkgname: "%NAME%-%version%"
       pkgroot: "%RECIPE_CACHE_DIR%/pkgroot"
       scripts: Scripts

--- a/MySQL/MySQLCommunityServer-Universal.pkg.recipe.yaml
+++ b/MySQL/MySQLCommunityServer-Universal.pkg.recipe.yaml
@@ -97,7 +97,6 @@ Process:
   Arguments:
     pkg_request:
       id: 'com.mysql.communityserver'
-      options: purge_ds_store
       pkgname: '%NAME%-%version%'
       pkgroot: '%RECIPE_CACHE_DIR%/pkgroot'
       pkgtype: flat

--- a/MySQL/MySQLWorkbench-Universal.pkg.recipe.yaml
+++ b/MySQL/MySQLWorkbench-Universal.pkg.recipe.yaml
@@ -157,7 +157,6 @@ Process:
   Arguments:
     pkg_request:
       id: '%bundleid%'
-      options: purge_ds_store
       pkgname: '%NAME%-%base_version%'
       pkgroot: '%RECIPE_CACHE_DIR%/pkgroot'
       pkgtype: flat

--- a/R/R-Universal.pkg.recipe.yaml
+++ b/R/R-Universal.pkg.recipe.yaml
@@ -97,7 +97,6 @@ Process:
     Arguments:
       pkg_request:
         id: "org.R-project.R.universal"
-        options: purge_ds_store
         pkgname: "%NAME%-%version%"
         pkgroot: "%RECIPE_CACHE_DIR%/pkgroot"
         pkgtype: flat

--- a/RealVNC/RealVNC Viewer.pkg.recipe
+++ b/RealVNC/RealVNC Viewer.pkg.recipe
@@ -64,8 +64,6 @@
 					<string>%cfbundle_version%</string>
 					<key>id</key>
 					<string>%cfbundle_identifier%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/SPSS Statistics/SPSSStatistics Patch.pkg.recipe
+++ b/SPSS Statistics/SPSSStatistics Patch.pkg.recipe
@@ -245,8 +245,6 @@ exit 0</string>
 					<string>%version%</string>
 					<key>id</key>
 					<string>com.ibm.spssstatistics</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>scripts</key>
 					<string>Scripts</string>
 				</dict>

--- a/SPSS Statistics/SPSSStatisticsLegacy.pkg.recipe
+++ b/SPSS Statistics/SPSSStatisticsLegacy.pkg.recipe
@@ -219,8 +219,6 @@ exit 0</string>
 					<string>%version%</string>
 					<key>id</key>
 					<string>com.ibm.spssstatistics</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>scripts</key>
 					<string>Scripts</string>
 				</dict>

--- a/Solstice/Solstice.pkg.recipe
+++ b/Solstice/Solstice.pkg.recipe
@@ -74,8 +74,6 @@ Download recipe's original author was @joshua-d-miller (https://github.com/autop
 				<dict>
 					<key>id</key>
 					<string>%bundle_id%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Spotify/Spotify-Universal.pkg.recipe.yaml
+++ b/Spotify/Spotify-Universal.pkg.recipe.yaml
@@ -157,7 +157,6 @@ Process:
   Arguments:
     pkg_request:
       id: '%bundleid%'
-      options: purge_ds_store
       pkgname: '%NAME%-%version%'
       pkgroot: '%RECIPE_CACHE_DIR%/pkgroot'
       pkgtype: flat

--- a/Tableau/TableauPublic-Universal.pkg.recipe.yaml
+++ b/Tableau/TableauPublic-Universal.pkg.recipe.yaml
@@ -85,7 +85,6 @@ Process:
     Arguments:
       pkg_request:
         id: 'com.tableausoftware.Public.app'
-        options: purge_ds_store
         pkgname: '%NAME%-%version%'
         pkgroot: '%RECIPE_CACHE_DIR%/pkgroot'
         pkgtype: flat

--- a/Tableau/TableauReader-Universal.pkg.recipe.yaml
+++ b/Tableau/TableauReader-Universal.pkg.recipe.yaml
@@ -85,7 +85,6 @@ Process:
     Arguments:
       pkg_request:
         id: 'com.tableausoftware.Reader.app'
-        options: purge_ds_store
         pkgname: '%NAME%-%version%'
         pkgroot: '%RECIPE_CACHE_DIR%/pkgroot'
         pkgtype: flat

--- a/Ultimaker Cura/UltimakerCura-Universal.pkg.recipe.yaml
+++ b/Ultimaker Cura/UltimakerCura-Universal.pkg.recipe.yaml
@@ -145,7 +145,6 @@ Process:
   Arguments:
     pkg_request:
       id: 'nl.ultimaker.cura'
-      options: purge_ds_store
       pkgname: '%NAME%-%version%'
       pkgroot: '%RECIPE_CACHE_DIR%/pkgroot'
       pkgtype: flat

--- a/VOSviewer/VOSviewer.pkg.recipe
+++ b/VOSviewer/VOSviewer.pkg.recipe
@@ -61,8 +61,6 @@ Java is *REQUIRED* to open VOSviewer.  Amazon's Corretto JDK is not compatiable 
 					<string>%version%</string>
 					<key>id</key>
 					<string>%cfbundle_identifier%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and remove the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._