### PR TITLE
LTR release changes the app name to QGIS-LTR so recipe fails

### DIFF
--- a/QGIS/QGIS.download.recipe
+++ b/QGIS/QGIS.download.recipe
@@ -42,7 +42,7 @@ Long Term (support) Release = "ltr"</string>
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%/QGIS.app</string>
+                <string>%pathname%/QGIS*.app</string>
                 <key>requirement</key>
                 <string>identifier "org.qgis.qgis3" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4F7N4UDA22"</string>
             </dict>


### PR DESCRIPTION
Added wildcard to app name in CodeSignatureVerifier processor so recipe doesn't fail when using LTR release.  It worked with the .pkg recipe too when I tested it but there might be references in there that need to be updated too (although I think as it's using the AppDmgVersioner processor it may not need any changes).